### PR TITLE
chore: insert jacoco plugin for test cpverage report in vscode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,25 @@
       <plugins>
         <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.4</version>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>prepare-agent</goal>
+                    </goals>
+                </execution>
+                <execution>
+                    <id>report</id>
+                    <phase>prepare-package</phase>
+                    <goals>
+                        <goal>report</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+        <plugin>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.1.0</version>
         </plugin>


### PR DESCRIPTION
1. run the following command in the terminal:
`mvn jacoco:prepare-agent test install jacoco:report`

2. navigate to the following path and open the HTML
`target/site/jacoco/index.html`

Current coverage is mostly empty which is expected as no module has not been merged
![image](https://github.com/batavia-orm/batavia/assets/89440444/54459152-e5b1-4d2b-9541-5a1ad4690c0a)
